### PR TITLE
FEATURE: Create jest setup for testing HTML semantics of components

### DIFF
--- a/DistributionPackages/Sitegeist.Site.Placeholder/Resources/Private/Fusion/Presentation/Component/Organism/SiteFooter/SiteFooter.spec.js
+++ b/DistributionPackages/Sitegeist.Site.Placeholder/Resources/Private/Fusion/Presentation/Component/Organism/SiteFooter/SiteFooter.spec.js
@@ -1,0 +1,14 @@
+import shell from 'shelljs';
+
+const COMPONENT = `Sitegeist.Site.Placeholder:Component.Organism.SiteFooter`;
+const RENDER = `./flow styleguide:render ${COMPONENT}`;
+
+describe(COMPONENT, () => {
+	describe(`Semantics`, () => {
+		it(`must be a <footer>. #semantics`, () => {
+			document.body.innerHTML = shell.exec(RENDER);
+
+			expect(document.body.firstChild.nodeName).toBe('FOOTER');
+		});
+	});
+});

--- a/DistributionPackages/Sitegeist.Site.Placeholder/Resources/Private/Fusion/Presentation/Component/Organism/SiteHeader/SiteHeader.spec.js
+++ b/DistributionPackages/Sitegeist.Site.Placeholder/Resources/Private/Fusion/Presentation/Component/Organism/SiteHeader/SiteHeader.spec.js
@@ -1,0 +1,14 @@
+import shell from 'shelljs';
+
+const COMPONENT = `Sitegeist.Site.Placeholder:Component.Organism.SiteHeader`;
+const RENDER = `./flow styleguide:render ${COMPONENT}`;
+
+describe(COMPONENT, () => {
+	describe(`Semantics`, () => {
+		it(`must be a <header>. #semantics`, () => {
+			document.body.innerHTML = shell.exec(RENDER);
+
+			expect(document.body.firstChild.nodeName).toBe('HEADER');
+		});
+	});
+});

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,11 @@ lint::
 	@$(MAKE) -s lint-css
 	@$(MAKE) -s lint-js
 
-test-e2e:
+test-e2e::
 	@docker-compose exec testcafe /opt/testcafe/docker/testcafe-docker.sh 'chromium --no-sandbox' /tests/*.ts
+
+test-component-semantics::
+	jest --verbose -t '#semantics'
 
 ###############################################################################
 #                               FRONTEND BUILD                                #
@@ -146,7 +149,7 @@ logs::
 	@docker-compose logs -f
 
 flow::
-	@docker-compose exec --user $$UID php-fpm ssh-agent /project/flow $(FLOW_ARGS)
+	@docker-compose exec -T --user $$UID php-fpm ssh-agent /project/flow $(FLOW_ARGS)
 
 ###############################################################################
 #                                  SSH                                        #

--- a/composer.lock
+++ b/composer.lock
@@ -4001,16 +4001,16 @@
         },
         {
             "name": "sitegeist/monocle",
-            "version": "v4.6.0",
+            "version": "v4.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sitegeist/Sitegeist.Monocle.git",
-                "reference": "82335cd60ca32fa28cbe8554a122c3beb321f1cb"
+                "reference": "8cfd9fb792c862227a2d0721d028684ad73d413b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sitegeist/Sitegeist.Monocle/zipball/82335cd60ca32fa28cbe8554a122c3beb321f1cb",
-                "reference": "82335cd60ca32fa28cbe8554a122c3beb321f1cb",
+                "url": "https://api.github.com/repos/sitegeist/Sitegeist.Monocle/zipball/8cfd9fb792c862227a2d0721d028684ad73d413b",
+                "reference": "8cfd9fb792c862227a2d0721d028684ad73d413b",
                 "shasum": ""
             },
             "require": {
@@ -4110,7 +4110,7 @@
                 }
             ],
             "description": "An living-styleguide for Neos that is based on the actual fusion-code",
-            "time": "2019-01-18T12:23:01+00:00"
+            "time": "2019-01-23T16:46:17+00:00"
         },
         {
             "name": "sitegeist/movealong",

--- a/flow
+++ b/flow
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make flow FLOW_ARGS="$(echo $@)"
+make -s flow FLOW_ARGS="$(echo $@)"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	testMatch: ['<rootDir>/DistributionPackages/*/Resources/Private/Fusion/**/*.spec.js']
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "postcss-selector-not": "^4.0.0",
     "precss": "^4.0.0",
     "promise-polyfill": "^8.1.0",
+    "shelljs": "^0.8.3",
     "style-loader": "^0.23.1",
     "stylelint": "^9.9.0",
     "testcafe": "^0.23.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4201,7 +4201,7 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -4743,7 +4743,7 @@ inquirer@^6.1.0:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-interpret@^1.1.0:
+interpret@^1.0.0, interpret@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
@@ -8229,6 +8229,13 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 redent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
@@ -8551,10 +8558,10 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.3.2, resolve@^1.8.1, resolve@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
-  integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.8.1, resolve@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  integrity sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==
   dependencies:
     path-parse "^1.0.6"
 
@@ -8753,6 +8760,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
**Note:** Preferrably, this PR should be merged after this one: https://github.com/sitegeist/Sitegeist.Monocle/pull/94. Together with an updated Sitegeist.Monocle dependency.

## What this does

This PR introduces a proper jest setup and one specific `make` target, that allows to run component tests that are tagged with `#semantics`. This allows us to run jest tests that are specific to HTML semantics independently from all other tests.

It also shows how those component tests could look like. Both, `Component.Organism.SiteHeader` and `Component.Organism.SiteFooter` have co-located Tests now with a simple check for HTML semantics.

## How to run

1. Clone the repository and set up the distribution
```
git clone git@github.com:sitegeist/sitegeist-neos-base-distribution.git
cd sitegeist-neos-base-distribution
make up
```

2. Run the tests
```
make test-component-semantics
```

Afterwards your output should be (ideally a bit more colourful than Markdown allows me to display):
```
 PASS  DistributionPackages/Sitegeist.Site.Placeholder/Resources/Private/Fusion/Presentation/Component/Organism/SiteFooter/SiteFooter.spec.js
  Sitegeist.Site.Placeholder:Component.Organism.SiteFooter
    Semantics
      ✓ must be a <footer>. #semantics (893ms)

 PASS  DistributionPackages/Sitegeist.Site.Placeholder/Resources/Private/Fusion/Presentation/Component/Organism/SiteHeader/SiteHeader.spec.js
  Sitegeist.Site.Placeholder:Component.Organism.SiteHeader
    Semantics
      ✓ must be a <header>. #semantics (968ms)

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        1.977s, estimated 2s
Ran all test suites with tests matching "#semantics".
```