### PR TITLE
FEATURE: Add the ability to override Makefile globally

### DIFF
--- a/Build/config.makefile
+++ b/Build/config.makefile
@@ -19,6 +19,10 @@ export PORT_ELASTICSEARCH=9200
 # ssh
 export CONF_SSH=./Docker/Config/ssh/config
 
+# local environment
+export DIR_CONFIG_GLOBAL=$(HOME)/.neos
+export DIR_CONFIG_LOCAL=./Custom
+
 config::
 	@echo ".env config"
 	@echo "______________________________________________"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ COMPOSE_EXEC_ROOT=docker-compose exec -T php-fpm
 export PATH := ./node_modules/.bin:./bin:$(PATH)
 
 -include ./Build/config.makefile
--include ./Custom/before.makefile
+-include $(DIR_CONFIG_GLOBAL)/before.makefile
+-include $(DIR_CONFIG_LOCAL)/before.makefile
 
 ###############################################################################
 #                                  README                                     #
@@ -50,7 +51,8 @@ environment::
 
 @install-githooks::
 	@if [ -z $${CI+x} ]; then $(MAKE) environment; fi
-	@if [ -z $${CI+x} ]; then cp ./.git/hooks/pre-commit.sample ./.git/hooks/pre-commit && echo "make lint" >> ./.git/hooks/pre-commit; fi
+	@if [ -z $${CI+x} ]; then cp ./.git/hooks/pre-commit.sample ./.git/hooks/pre-commit && \
+		echo "make lint" >> ./.git/hooks/pre-commit; fi
 
 @install-composer::
 	@$(COMPOSE_EXEC) composer install
@@ -175,4 +177,5 @@ deploy-live::
 	@echo "ERROR: There's no live deployment configured yet"
 	@exit 1
 
--include ./Custom/after.makefile
+-include $(DIR_CONFIG_GLOBAL)/after.makefile
+-include $(DIR_CONFIG_LOCAL)/after.makefile


### PR DESCRIPTION
This adds the possibility to store `before.makefile` and `after.makefile` in some global directory (by default: `~/.neos`).

This allows developers to override Makefiles provided by this repository across all projects.