### PR TITLE
TASK: Enable `subdivideHashPathSegment` and `relativeSymlinks` by default

### DIFF
--- a/Configuration/Settings.Resources.yaml
+++ b/Configuration/Settings.Resources.yaml
@@ -1,0 +1,15 @@
+Neos:
+  Flow:
+    resource:
+      targets:
+        localWebDirectoryPersistentResourcesTarget:
+          targetOptions:
+
+            # split published urls into folters to avoid 
+            # running into fs folder limits
+            subdivideHashPathSegment: true
+
+            # use relative links to allow putting of
+            # Web/_Resources/Persistent into the shared 
+            # folder for faster deployments   
+            relativeSymlinks: true


### PR DESCRIPTION
See https://github.com/neos/flow-development-collection/pull/1689 for the reasoning behind.