### PR TITLE
Add .ddev/docker-compose.custom.yaml to .gitignore by default

### DIFF
--- a/.ddev/.gitignore
+++ b/.ddev/.gitignore
@@ -19,3 +19,4 @@
 /.webimageExtra
 /.dbimageExtra
 /*-build/Dockerfile.example
+/docker-compose.custom.yaml


### PR DESCRIPTION
This allows every developer to define custom docker-compose configuration for all of our DDEV projects.