### PR TITLE
Add phpstan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ test-component-semantics::
 test::
 	@$(MAKE) -s test-component-semantics
 
+analyse::
+	@ddev exec bin/phpstan analyse --level 8 DistributionPackages
+
 ###############################################################################
 #                               FRONTEND BUILD                                #
 ###############################################################################

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "editorconfig-checker/editorconfig-checker": "^10.0",
         "squizlabs/php_codesniffer": "^3.4",
         "sitegeist/magicwand": "^4.0",
-        "sitegeist/chantalle": "~1.0.1"
+        "sitegeist/chantalle": "~1.0.1",
+        "phpstan/phpstan": "^0.12.42"
     },
     "suggest": {
         "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ddbc5fa5e44db7cd36dc0447699c18a",
+    "content-hash": "bd38c02151323426cbb32102c8f44b82",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -5979,6 +5979,9 @@
                 "psr-4": {
                     "Vendor\\Site\\": "Classes/"
                 }
+            },
+            "transport-options": {
+                "relative": true
             }
         },
         {
@@ -6754,6 +6757,62 @@
                 "stub"
             ],
             "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
+                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-02T13:14:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -8108,5 +8167,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR adds `phpstan/phpstan` to our dev dependencies with an accompanying make target for static code analysis of all our distribution packages.

**Background:**

PHPStan (https://phpstan.org/) is a static code analysis tool for PHP, which allows to run static type checks before runtime (e.g. in development and CI environments).

It not only utilizes PHPs built-in type system, but also provides various advanced type annotations to allow for static analysis of generics, union and intersection types, literals and even array shapes.

Having this extra step of static analysis would prevent a lot of type-related bugs, that otherwise would only be caught at runtime. It also allows for much safer code refactorings.