### PR TITLE
Activate assertions in php container

### DIFF
--- a/.ddev/php/php.ini
+++ b/.ddev/php/php.ini
@@ -1,0 +1,5 @@
+#
+# Activate assertions for development
+#
+zend.assertions=1
+assert.exception=1


### PR DESCRIPTION
This PR activates PHP assertions for our development environments.

**Background:**

Assertions (see: https://www.php.net/manual/de/function.assert.php) are a built-in PHP mechanism for zero-production-cost runtime checks, that only run, if `zend.assertions` is set to `1`.

This allows us to run checks like this:

```
assert($node->getNodeType()->isOfType('Vendor.Site:Document.News'), new \InvalidArgumentException('Node must be a News Document!'));
assert(isset($query['givenName'], new \InvalidArgumentException('givenName must be set!'));
```

To check conditions that must never be true, but are only relevant during development, because they shouldn't ever occur in production.

This gives us an extra layer of security and more opportunity to discover bugs exactly where they occur.
