### PR TITLE
TASK: Add optimisation for png and jpg images

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -25,7 +25,7 @@ web_environment:
 - FLOW_REWRITEURLS=1
 - FLOW_PATH_TEMPORARY_BASE=/tmp/neos
 - FLOW_ROOTPATH=/var/www/html
-
+webimage_extra_packages: [pngquant,jpegoptim]
 
 # This config.yaml was created with ddev version v1.18.0-alpha4
 # webimage: drud/ddev-webserver:20210729_cspitzlay_mysql_history

--- a/Configuration/Development/ddev/Settings.ImageOptimizer.yaml
+++ b/Configuration/Development/ddev/Settings.ImageOptimizer.yaml
@@ -1,0 +1,23 @@
+MOC:
+  ImageOptimizer:
+    formats:
+      #
+      # Configuration for image optimization in the ddev evironment
+      #
+      'image/jpeg':
+        enabled: true
+        useGlobalBinary: true
+        library: 'jpegoptim'
+        arguments: "${'--strip-all --max=' + quality + ' ' + (progressive ? '--all-progressive ' : '') + '-o ' + file}"
+        parameters:
+          progressive: true
+          quality: 90
+
+      'image/png':
+        enabled: true
+        useGlobalBinary: true
+        library: 'pngquant'
+        arguments: "${'--quality=' + qualityMin + '-' + qualityMax + ' --skip-if-larger --strip --force -o ' + file + ' ' + file}"
+        parameters:
+          qualityMin: 80
+          qualityMax: 90

--- a/Configuration/Settings.ImageOptimizer.yaml
+++ b/Configuration/Settings.ImageOptimizer.yaml
@@ -1,0 +1,25 @@
+MOC:
+  ImageOptimizer:
+    formats:
+
+      #
+      # The binaries and pathes have to be configured for the server environment
+      # in the Production/Settings.yaml on the server
+      #
+      'image/jpeg':
+        enabled: false
+
+      'image/png':
+        enabled: false
+
+      # No good optimizer found yet
+      'image/webp':
+        enabled: false
+
+      # Rarely needed ... not worth the hassle
+      'image/gif':
+        enabled: false
+
+      # Optimized by gzip
+      'image/svg+xml':
+        enabled: false

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "sitegeist/stampede": "^1.1",
         "sitegeist/archaeopteryx": "^1.0",
 
-        "vendor/site": "^1.0"
+        "vendor/site": "^1.0",
+        "moc/imageoptimizer": "^4.0"
     },
     "require-dev": {
         "neos/buildessentials": "^7.1",


### PR DESCRIPTION
To be used on the production environment tools like pngquant and jpegoptim have to be installed on the server
and configured in the Production/Settings.yaml.

The included configuration adds optimizations for png and jpg to the ddev environment.
The compression is improved about 20% for JPG and 80% for PNG.