### PR TITLE
TASK: Remove lastVisitedNode.js

### DIFF
--- a/DistributionPackages/Vendor.Site/Resources/Private/Fusion/Configuration/Neos.Page.fusion
+++ b/DistributionPackages/Vendor.Site/Resources/Private/Fusion/Configuration/Neos.Page.fusion
@@ -7,5 +7,5 @@ prototype(Neos.Neos:Page) {
     // it is disabled as only editors would benefit but
     // all user would see the additional request
     //
-    lastVisitedNodeScript.@if.disabled = false
+    lastVisitedNodeScript.@if.enabled = false
 }

--- a/DistributionPackages/Vendor.Site/Resources/Private/Fusion/Configuration/Neos.Page.fusion
+++ b/DistributionPackages/Vendor.Site/Resources/Private/Fusion/Configuration/Neos.Page.fusion
@@ -1,0 +1,11 @@
+//
+// Neos.Neos:Page Configuration
+//
+prototype(Neos.Neos:Page) {
+    //
+    // the last visited node is an unwanted side effect
+    // it is disabled as only editors would benefit but
+    // all user would see the additional request
+    //
+    lastVisitedNodeScript.@if.disabled = false
+}


### PR DESCRIPTION
The last visited node is an unwanted side effect. It is disabled as only editors would benefit but all user would see the additional request.